### PR TITLE
Fix test for 01_sell_nft

### DIFF
--- a/01_sell_nft/scripts/task.ts
+++ b/01_sell_nft/scripts/task.ts
@@ -263,7 +263,8 @@ export async function test(
   const datum1 = Data.from(gameData.scriptUtxos[0].datum, SellNFTDatum);
   const datum2 = Data.from(gameData.scriptUtxos[1].datum, SellNFTDatum);
 
-  const spentFunds = endBalance - gameData.originalBalance;
+  const spentFunds = gameData.originalBalance - endBalance;
+
   if (spentFunds < datum1.price + datum2.price) {
     passTest(
       `TEST 3 PASSED - you spent less than the price of both NFTs`,


### PR DESCRIPTION
The current operation returns a negative number, making the condition always true - even when the full amount is paid to the contract.